### PR TITLE
feat: make operations parallel

### DIFF
--- a/pkg/operations.go
+++ b/pkg/operations.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path"
+	"sync"
 )
 
 type DependencyCommand string
@@ -28,50 +29,101 @@ func ProcessCharts(rootDir string, operation ChartOperation, cmd DependencyComma
 		return err
 	}
 
-	for i := len(charts) - 1; i >= 0; i-- {
-		chart := charts[i]
-		var helmCmd *exec.Cmd
-
-		switch operation {
-		case OperationDependency:
-			helmCmd = exec.Command("helm", "dependency", string(cmd), chart.path)
-		case OperationLint:
-			helmCmd = exec.Command("helm", "lint", chart.path, "--values", path.Join(rootDir, "values.yaml"))
-		default:
-			errorMsg := fmt.Sprintf("Error: unsupported operation: %s", operation)
-			return fmt.Errorf("%s", ErrorColor.Sprint(errorMsg))
-		}
-
-		var stdout, stderr bytes.Buffer
-		helmCmd.Stdout = &stdout
-		helmCmd.Stderr = &stderr
-
-		if err := helmCmd.Run(); err != nil {
-			switch operation {
-			case OperationDependency:
-				errorMsg := fmt.Sprintf("Error: failed to %s dependencies for %s:\n%s", cmd, chart.path, stderr.String())
-				return fmt.Errorf("%s", ErrorColor.Sprint(errorMsg))
-			case OperationLint:
-				errorMsg := fmt.Sprintf("Error: failed to lint chart %s:\n%s", chart.path, stderr.String())
-				return fmt.Errorf("%s", ErrorColor.Sprint(errorMsg))
-			}
-		}
-		if stderr.String() != "" {
-			fmt.Printf("%s\n", WarningColor.Sprint(stderr.String()))
-		}
-
-		switch operation {
-		case OperationDependency:
-			var successMsg string
-			if cmd == Build {
-				successMsg = "dependencies built successfully"
-			} else {
-				successMsg = "dependencies updated successfully"
-			}
-			fmt.Printf("%s %s\n", ChartColor.Sprint(chart.metadata.Name), successMsg)
-		case OperationLint:
-			fmt.Printf("%s linted successfully\n", ChartColor.Sprint(chart.metadata.Name))
+	chartsByLevel := make(map[int][]Chart)
+	maxLevel := 0
+	for _, chart := range charts {
+		level := chart.level
+		chartsByLevel[level] = append(chartsByLevel[level], chart)
+		if level > maxLevel {
+			maxLevel = level
 		}
 	}
+
+	// Process levels from deepest to shallowest (maxLevel down to 0)
+	// Charts at the same level can be processed in parallel
+	for level := maxLevel; level >= 0; level-- {
+		levelCharts, exists := chartsByLevel[level]
+		if !exists {
+			continue
+		}
+
+		// Process all charts at this level in parallel
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		var firstErr error
+
+		for _, chart := range levelCharts {
+			wg.Add(1)
+			go func(ch Chart) {
+				defer wg.Done()
+
+				var helmCmd *exec.Cmd
+
+				switch operation {
+				case OperationDependency:
+					helmCmd = exec.Command("helm", "dependency", string(cmd), ch.path)
+				case OperationLint:
+					helmCmd = exec.Command("helm", "lint", ch.path, "--values", path.Join(rootDir, "values.yaml"))
+				default:
+					mu.Lock()
+					if firstErr == nil {
+						errorMsg := fmt.Sprintf("Error: unsupported operation: %s", operation)
+						firstErr = fmt.Errorf("%s", ErrorColor.Sprint(errorMsg))
+					}
+					mu.Unlock()
+					return
+				}
+
+				var stdout, stderr bytes.Buffer
+				helmCmd.Stdout = &stdout
+				helmCmd.Stderr = &stderr
+
+				if err := helmCmd.Run(); err != nil {
+					mu.Lock()
+					if firstErr == nil {
+						switch operation {
+						case OperationDependency:
+							errorMsg := fmt.Sprintf("Error: failed to %s dependencies for %s:\n%s", cmd, ch.path, stderr.String())
+							firstErr = fmt.Errorf("%s", ErrorColor.Sprint(errorMsg))
+						case OperationLint:
+							errorMsg := fmt.Sprintf("Error: failed to lint chart %s:\n%s", ch.path, stderr.String())
+							firstErr = fmt.Errorf("%s", ErrorColor.Sprint(errorMsg))
+						}
+					}
+					mu.Unlock()
+					return
+				}
+
+				// Synchronize output to avoid interleaving
+				mu.Lock()
+				if stderr.String() != "" {
+					fmt.Printf("%s\n", WarningColor.Sprint(stderr.String()))
+				}
+
+				switch operation {
+				case OperationDependency:
+					var successMsg string
+					if cmd == Build {
+						successMsg = "dependencies built successfully"
+					} else {
+						successMsg = "dependencies updated successfully"
+					}
+					fmt.Printf("%s %s\n", ChartColor.Sprint(ch.metadata.Name), successMsg)
+				case OperationLint:
+					fmt.Printf("%s linted successfully\n", ChartColor.Sprint(ch.metadata.Name))
+				}
+				mu.Unlock()
+			}(chart)
+		}
+
+		// Wait for all charts at this level to complete
+		wg.Wait()
+
+		// If any chart at this level failed, return the error
+		if firstErr != nil {
+			return firstErr
+		}
+	}
+
 	return nil
 }

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "cascade"
-version: "1.1.1"
+version: "1.2.0"
 usage: "Recursively manages Helm chart dependencies across all subcharts"
 description: "Recursively manages Helm chart dependencies across all subcharts"
 ignoreFlags: false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Parallelizes Helm chart operations by processing charts in level-based batches with synchronized output and error handling; updates plugin version to 1.2.0.
> 
> - **Core (pkg/operations.go)**:
>   - Group charts by `level` and process from deepest to shallowest.
>   - Execute charts at the same level in parallel using `WaitGroup` and `Mutex`.
>   - Capture first error per level and abort after level completes; synchronize stdout/stderr to avoid interleaving.
>   - Maintain existing behaviors for `dependency {build|update}` and `lint` commands and success/warning messaging.
> - **Plugin**:
>   - Bump `plugin.yaml` version from `1.1.1` to `1.2.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86f8b7383ea24009484689b7ea1142d85c3086e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->